### PR TITLE
Implement Azure Key Vault credential filler

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,27 @@
+module.exports = [
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 6,
+      sourceType: 'script',
+      globals: {
+        chrome: 'readonly',
+        browser: 'readonly',
+        module: 'writable',
+        require: 'readonly'
+      }
+    },
+    rules: {
+      semi: ['error', 'always'],
+      strict: ['error', 'function'],
+      'no-unused-vars': 'error',
+      indent: ['error', 'tab'],
+      'no-const-assign': 'error',
+      'one-var': 'error',
+      'prefer-const': 'error',
+      'no-var': 'error',
+      'no-plusplus': 'off',
+      quotes: ['error', 'single', { avoidEscape: true, allowTemplateLiterals: true }]
+    }
+  }
+];

--- a/src/lib/azure-keyvault-client.js
+++ b/src/lib/azure-keyvault-client.js
@@ -1,0 +1,39 @@
+module.exports = function AzureKeyVaultClient(settings) {
+        'use strict';
+        let opts = settings || {},
+                apiVersion = opts.apiVersion || '7.1';
+        const vaultUrl = opts.url ? opts.url.replace(/\/$/, '') : '',
+                authToken = opts.pat || opts.token;
+        const toSecretName = function (identifier) {
+                        return identifier.replace(/_/g, '---')
+                                .replace(/@/g, '--')
+                                .replace(/\./g, '-');
+                },
+                getSecret = function (identifier) {
+                        const name = toSecretName(identifier),
+                                url = vaultUrl + '/secrets/' + name + '?api-version=' + apiVersion;
+                        return fetch(url, {
+                                method: 'GET',
+                                headers: { 'Authorization': 'Bearer ' + authToken }
+                        }).then(response => {
+                                if (!response.ok) {
+                                        throw new Error('Error fetching secret');
+                                }
+                                return response.json();
+                        }).then(data => data.value);
+                },
+                setSecret = function (identifier, value) {
+                        const name = toSecretName(identifier),
+                                url = vaultUrl + '/secrets/' + name + '?api-version=' + apiVersion;
+                        return fetch(url, {
+                                method: 'PUT',
+                                headers: { 'Authorization': 'Bearer ' + authToken, 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ value: value })
+                        }).then(response => {
+                                if (!response.ok) {
+                                        throw new Error('Error setting secret');
+                                }
+                        });
+                };
+        return { getSecret: getSecret, setSecret: setSecret, toSecretName: toSecretName };
+};

--- a/src/lib/azure-keyvault-client.js
+++ b/src/lib/azure-keyvault-client.js
@@ -1,39 +1,39 @@
 module.exports = function AzureKeyVaultClient(settings) {
-        'use strict';
-        let opts = settings || {},
-                apiVersion = opts.apiVersion || '7.1';
-        const vaultUrl = opts.url ? opts.url.replace(/\/$/, '') : '',
-                authToken = opts.pat || opts.token;
-        const toSecretName = function (identifier) {
-                        return identifier.replace(/_/g, '---')
-                                .replace(/@/g, '--')
-                                .replace(/\./g, '-');
-                },
-                getSecret = function (identifier) {
-                        const name = toSecretName(identifier),
-                                url = vaultUrl + '/secrets/' + name + '?api-version=' + apiVersion;
-                        return fetch(url, {
-                                method: 'GET',
-                                headers: { 'Authorization': 'Bearer ' + authToken }
-                        }).then(response => {
-                                if (!response.ok) {
-                                        throw new Error('Error fetching secret');
-                                }
-                                return response.json();
-                        }).then(data => data.value);
-                },
-                setSecret = function (identifier, value) {
-                        const name = toSecretName(identifier),
-                                url = vaultUrl + '/secrets/' + name + '?api-version=' + apiVersion;
-                        return fetch(url, {
-                                method: 'PUT',
-                                headers: { 'Authorization': 'Bearer ' + authToken, 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ value: value })
-                        }).then(response => {
-                                if (!response.ok) {
-                                        throw new Error('Error setting secret');
-                                }
-                        });
-                };
-        return { getSecret: getSecret, setSecret: setSecret, toSecretName: toSecretName };
+	'use strict';
+	const opts = settings || {},
+		apiVersion = opts.apiVersion || '7.1',
+	 vaultUrl = opts.url ? opts.url.replace(/\/$/, '') : '',
+		authToken = opts.pat || opts.token,
+		toSecretName = function (identifier) {
+			return identifier.replace(/_/g, '---')
+				.replace(/@/g, '--')
+				.replace(/\./g, '-');
+		},
+		getSecret = function (identifier) {
+			const name = toSecretName(identifier),
+				url = vaultUrl + '/secrets/' + name + '?api-version=' + apiVersion;
+			return fetch(url, {
+				method: 'GET',
+				headers: { 'Authorization': 'Bearer ' + authToken }
+			}).then(response => {
+				if (!response.ok) {
+					throw new Error('Error fetching secret');
+				}
+				return response.json();
+			}).then(data => data.value);
+		},
+		setSecret = function (identifier, value) {
+			const name = toSecretName(identifier),
+				url = vaultUrl + '/secrets/' + name + '?api-version=' + apiVersion;
+			return fetch(url, {
+				method: 'PUT',
+				headers: { 'Authorization': 'Bearer ' + authToken, 'Content-Type': 'application/json' },
+				body: JSON.stringify({ value: value })
+			}).then(response => {
+				if (!response.ok) {
+					throw new Error('Error setting secret');
+				}
+			});
+		};
+	return { getSecret: getSecret, setSecret: setSecret, toSecretName: toSecretName };
 };

--- a/src/lib/credential-context-menu.js
+++ b/src/lib/credential-context-menu.js
@@ -1,35 +1,35 @@
 const fillCredentialsHandler = require('./fill-credentials-request-handler');
 module.exports = function CredentialContextMenu(browserInterface) {
-        'use strict';
-        const self = this;
-        let rootId,
-                menuIds = [];
-        const buildMenu = function () {
-                        if (rootId) {
-                                chrome.contextMenus.remove(rootId);
-                                menuIds.forEach(id => chrome.contextMenus.remove(id));
-                                menuIds = [];
-                                rootId = null;
-                        }
-                        return browserInterface.getOptionsAsync().then(opts => {
-                                const accounts = opts && opts.accounts;
-                                if (!accounts || !accounts.length) {
-                                        return;
-                                }
-                                rootId = chrome.contextMenus.create({title: 'Test Accounts', contexts: ['editable']});
-                                accounts.forEach(acc => {
-                                        const id = chrome.contextMenus.create({
-                                                title: acc,
-                                                parentId: rootId,
-                                                contexts: ['editable'],
-                                                onclick: (info, tab) => fillCredentialsHandler(browserInterface, tab.id, acc)
-                                        });
-                                        menuIds.push(id);
-                                });
-                        });
-                };
-        self.init = function () {
-                buildMenu();
-                browserInterface.addStorageListener(buildMenu);
-        };
+	'use strict';
+	const self = this,
+		buildMenu = function () {
+			if (rootId) {
+				chrome.contextMenus.remove(rootId);
+				menuIds.forEach(id => chrome.contextMenus.remove(id));
+				menuIds = [];
+				rootId = null;
+			}
+			return browserInterface.getOptionsAsync().then(opts => {
+				const accounts = opts && opts.accounts;
+				if (!accounts || !accounts.length) {
+					return;
+				}
+				rootId = chrome.contextMenus.create({title: 'Test Accounts', contexts: ['editable']});
+				accounts.forEach(acc => {
+					const id = chrome.contextMenus.create({
+						title: acc,
+						parentId: rootId,
+						contexts: ['editable'],
+						onclick: (info, tab) => fillCredentialsHandler(browserInterface, tab.id, acc)
+					});
+					menuIds.push(id);
+				});
+			});
+		};
+	let rootId,
+		menuIds = [];
+	self.init = function () {
+		buildMenu();
+		browserInterface.addStorageListener(buildMenu);
+	};
 };

--- a/src/lib/credential-context-menu.js
+++ b/src/lib/credential-context-menu.js
@@ -1,0 +1,35 @@
+const fillCredentialsHandler = require('./fill-credentials-request-handler');
+module.exports = function CredentialContextMenu(browserInterface) {
+        'use strict';
+        const self = this;
+        let rootId,
+                menuIds = [];
+        const buildMenu = function () {
+                        if (rootId) {
+                                chrome.contextMenus.remove(rootId);
+                                menuIds.forEach(id => chrome.contextMenus.remove(id));
+                                menuIds = [];
+                                rootId = null;
+                        }
+                        return browserInterface.getOptionsAsync().then(opts => {
+                                const accounts = opts && opts.accounts;
+                                if (!accounts || !accounts.length) {
+                                        return;
+                                }
+                                rootId = chrome.contextMenus.create({title: 'Test Accounts', contexts: ['editable']});
+                                accounts.forEach(acc => {
+                                        const id = chrome.contextMenus.create({
+                                                title: acc,
+                                                parentId: rootId,
+                                                contexts: ['editable'],
+                                                onclick: (info, tab) => fillCredentialsHandler(browserInterface, tab.id, acc)
+                                        });
+                                        menuIds.push(id);
+                                });
+                        });
+                };
+        self.init = function () {
+                buildMenu();
+                browserInterface.addStorageListener(buildMenu);
+        };
+};

--- a/src/lib/credential-manager.js
+++ b/src/lib/credential-manager.js
@@ -6,7 +6,7 @@ module.exports = function CredentialManager(browserInterface) {
         const loadOptions = function () {
                         return browserInterface.getOptionsAsync().then(opts => {
                                 options = opts || {};
-                                client = new AzureKeyVaultClient({ url: options.vaultUrl, pat: options.vaultPat });
+                                client = new AzureKeyVaultClient({ url: options.vaultUrl, pat: options.vaultPat, token: options.vaultToken });
                         });
                 };
         this.getAccounts = function () {

--- a/src/lib/credential-manager.js
+++ b/src/lib/credential-manager.js
@@ -1,0 +1,24 @@
+const AzureKeyVaultClient = require('./azure-keyvault-client');
+module.exports = function CredentialManager(browserInterface) {
+        'use strict';
+        let options = {},
+                client;
+        const loadOptions = function () {
+                        return browserInterface.getOptionsAsync().then(opts => {
+                                options = opts || {};
+                                client = new AzureKeyVaultClient({ url: options.vaultUrl, pat: options.vaultPat });
+                        });
+                };
+        this.getAccounts = function () {
+                return loadOptions().then(() => options.accounts || []);
+        };
+        this.fillCredentials = function (tabId, accountId) {
+                return loadOptions().then(() => client.getSecret(accountId)
+                        .then(password => browserInterface.executeScript(tabId, '/credential-fill.js')
+                                .then(() => browserInterface.sendMessage(tabId, { username: accountId, password: password }))
+                        ));
+        };
+        this.updatePassword = function (accountId, newPassword) {
+                return loadOptions().then(() => client.setSecret(accountId, newPassword));
+        };
+};

--- a/src/lib/credential-manager.js
+++ b/src/lib/credential-manager.js
@@ -1,24 +1,24 @@
 const AzureKeyVaultClient = require('./azure-keyvault-client');
 module.exports = function CredentialManager(browserInterface) {
-        'use strict';
-        let options = {},
-                client;
-        const loadOptions = function () {
-                        return browserInterface.getOptionsAsync().then(opts => {
-                                options = opts || {};
-                                client = new AzureKeyVaultClient({ url: options.vaultUrl, pat: options.vaultPat, token: options.vaultToken });
-                        });
-                };
-        this.getAccounts = function () {
-                return loadOptions().then(() => options.accounts || []);
-        };
-        this.fillCredentials = function (tabId, accountId) {
-                return loadOptions().then(() => client.getSecret(accountId)
-                        .then(password => browserInterface.executeScript(tabId, '/credential-fill.js')
-                                .then(() => browserInterface.sendMessage(tabId, { username: accountId, password: password }))
-                        ));
-        };
-        this.updatePassword = function (accountId, newPassword) {
-                return loadOptions().then(() => client.setSecret(accountId, newPassword));
-        };
+	'use strict';
+	let options = {},
+		client;
+	const loadOptions = function () {
+		return browserInterface.getOptionsAsync().then(opts => {
+			options = opts || {};
+			client = new AzureKeyVaultClient({ url: options.vaultUrl, pat: options.vaultPat, token: options.vaultToken });
+		});
+	};
+	this.getAccounts = function () {
+		return loadOptions().then(() => options.accounts || []);
+	};
+	this.fillCredentials = function (tabId, accountId) {
+		return loadOptions().then(() => client.getSecret(accountId)
+			.then(password => browserInterface.executeScript(tabId, '/credential-fill.js')
+				.then(() => browserInterface.sendMessage(tabId, { username: accountId, password: password }))
+			));
+	};
+	this.updatePassword = function (accountId, newPassword) {
+		return loadOptions().then(() => client.setSecret(accountId, newPassword));
+	};
 };

--- a/src/lib/fill-credentials-request-handler.js
+++ b/src/lib/fill-credentials-request-handler.js
@@ -1,6 +1,6 @@
 const CredentialManager = require('./credential-manager');
 module.exports = function fillCredentialsRequestHandler(browserInterface, tabId, account) {
-        'use strict';
-        const manager = new CredentialManager(browserInterface);
-        return manager.fillCredentials(tabId, account);
+	'use strict';
+	const manager = new CredentialManager(browserInterface);
+	return manager.fillCredentials(tabId, account);
 };

--- a/src/lib/fill-credentials-request-handler.js
+++ b/src/lib/fill-credentials-request-handler.js
@@ -1,0 +1,6 @@
+const CredentialManager = require('./credential-manager');
+module.exports = function fillCredentialsRequestHandler(browserInterface, tabId, account) {
+        'use strict';
+        const manager = new CredentialManager(browserInterface);
+        return manager.fillCredentials(tabId, account);
+};

--- a/src/lib/init-credential-widget.js
+++ b/src/lib/init-credential-widget.js
@@ -1,28 +1,29 @@
 module.exports = function initCredentialWidget(domElement, browserInterface) {
-        'use strict';
-        let vaultField = domElement.querySelector('[role=vault-url]'),
-                patField = domElement.querySelector('[role=vault-pat]'),
-                tokenField = domElement.querySelector('[role=vault-token]'),
-                accountsField = domElement.querySelector('[role=accounts]'),
-                status = domElement.querySelector('[role=cred-status]');
-        const restore = function () {
-                        return browserInterface.getOptionsAsync().then(opts => {
-                                vaultField.value = opts.vaultUrl || '';
-                                patField.value = opts.vaultPat || '';
-                                tokenField.value = opts.vaultToken || '';
-                                accountsField.value = Array.isArray(opts.accounts) ? JSON.stringify(opts.accounts, null, 2) : '[]';
-                        });
-                },
-                save = function () {
-                        try {
-                                const acc = accountsField.value ? JSON.parse(accountsField.value) : [];
-                                browserInterface.saveOptions({ vaultUrl: vaultField.value, vaultPat: patField.value, vaultToken: tokenField.value, accounts: acc });
-                                status.textContent = 'Saved';
-                                setTimeout(() => status.textContent = '', 1000);
-                        } catch (e) {
-                                status.textContent = 'Invalid accounts JSON';
-                        }
-                };
-        domElement.querySelector('[role=save-credentials]').addEventListener('click', save);
-        restore();
+	'use strict';
+	const vaultField = domElement.querySelector('[role=vault-url]'),
+		patField = domElement.querySelector('[role=vault-pat]'),
+		tokenField = domElement.querySelector('[role=vault-token]'),
+		accountsField = domElement.querySelector('[role=accounts]'),
+		status = domElement.querySelector('[role=cred-status]'),
+	 restore = function () {
+			return browserInterface.getOptionsAsync().then(opts => {
+				vaultField.value = opts.vaultUrl || '';
+				patField.value = opts.vaultPat || '';
+				tokenField.value = opts.vaultToken || '';
+				accountsField.value = Array.isArray(opts.accounts) ? JSON.stringify(opts.accounts, null, 2) : '[]';
+			});
+		},
+		save = function () {
+			try {
+				const acc = accountsField.value ? JSON.parse(accountsField.value) : [];
+				browserInterface.saveOptions({ vaultUrl: vaultField.value, vaultPat: patField.value, vaultToken: tokenField.value, accounts: acc });
+				status.textContent = 'Saved';
+				setTimeout(() => status.textContent = '', 1000);
+			} catch (e) {
+				console.error(e);
+				status.textContent = 'Invalid accounts JSON';
+			}
+		};
+	domElement.querySelector('[role=save-credentials]').addEventListener('click', save);
+	restore();
 };

--- a/src/lib/init-credential-widget.js
+++ b/src/lib/init-credential-widget.js
@@ -2,19 +2,21 @@ module.exports = function initCredentialWidget(domElement, browserInterface) {
         'use strict';
         let vaultField = domElement.querySelector('[role=vault-url]'),
                 patField = domElement.querySelector('[role=vault-pat]'),
+                tokenField = domElement.querySelector('[role=vault-token]'),
                 accountsField = domElement.querySelector('[role=accounts]'),
                 status = domElement.querySelector('[role=cred-status]');
         const restore = function () {
                         return browserInterface.getOptionsAsync().then(opts => {
                                 vaultField.value = opts.vaultUrl || '';
                                 patField.value = opts.vaultPat || '';
+                                tokenField.value = opts.vaultToken || '';
                                 accountsField.value = Array.isArray(opts.accounts) ? JSON.stringify(opts.accounts, null, 2) : '[]';
                         });
                 },
                 save = function () {
                         try {
                                 const acc = accountsField.value ? JSON.parse(accountsField.value) : [];
-                                browserInterface.saveOptions({ vaultUrl: vaultField.value, vaultPat: patField.value, accounts: acc });
+                                browserInterface.saveOptions({ vaultUrl: vaultField.value, vaultPat: patField.value, vaultToken: tokenField.value, accounts: acc });
                                 status.textContent = 'Saved';
                                 setTimeout(() => status.textContent = '', 1000);
                         } catch (e) {

--- a/src/lib/init-credential-widget.js
+++ b/src/lib/init-credential-widget.js
@@ -1,0 +1,26 @@
+module.exports = function initCredentialWidget(domElement, browserInterface) {
+        'use strict';
+        let vaultField = domElement.querySelector('[role=vault-url]'),
+                patField = domElement.querySelector('[role=vault-pat]'),
+                accountsField = domElement.querySelector('[role=accounts]'),
+                status = domElement.querySelector('[role=cred-status]');
+        const restore = function () {
+                        return browserInterface.getOptionsAsync().then(opts => {
+                                vaultField.value = opts.vaultUrl || '';
+                                patField.value = opts.vaultPat || '';
+                                accountsField.value = Array.isArray(opts.accounts) ? JSON.stringify(opts.accounts, null, 2) : '[]';
+                        });
+                },
+                save = function () {
+                        try {
+                                const acc = accountsField.value ? JSON.parse(accountsField.value) : [];
+                                browserInterface.saveOptions({ vaultUrl: vaultField.value, vaultPat: patField.value, accounts: acc });
+                                status.textContent = 'Saved';
+                                setTimeout(() => status.textContent = '', 1000);
+                        } catch (e) {
+                                status.textContent = 'Invalid accounts JSON';
+                        }
+                };
+        domElement.querySelector('[role=save-credentials]').addEventListener('click', save);
+        restore();
+};

--- a/src/main/credential-fill.js
+++ b/src/main/credential-fill.js
@@ -1,48 +1,48 @@
 /*global chrome*/
 (function () {
-        'use strict';
-        const fillAndSubmit = function (username, password) {
-                        const userField = document.querySelector('input[type=email], input[name*=email], input[name*=user], input[type=text]');
-                        if (userField) {
-                                userField.focus();
-                                userField.value = username;
-                                userField.dispatchEvent(new Event('input', {bubbles: true}));
-                                userField.dispatchEvent(new Event('change', {bubbles: true}));
-                                const passField = document.querySelector('input[type=password]');
-                                if (passField) {
-                                        passField.focus();
-                                        passField.value = password;
-                                        passField.dispatchEvent(new Event('input', {bubbles: true}));
-                                        passField.dispatchEvent(new Event('change', {bubbles: true}));
-                                        passField.form && passField.form.submit();
-                                } else {
-                                        userField.form && userField.form.submit();
-                                        window.addEventListener('load', () => {
-                                                const pf = document.querySelector('input[type=password]');
-                                                if (pf) {
-                                                        pf.focus();
-                                                        pf.value = password;
-                                                        pf.dispatchEvent(new Event('input', {bubbles: true}));
-                                                        pf.dispatchEvent(new Event('change', {bubbles: true}));
-                                                        pf.form && pf.form.submit();
-                                                }
-                                        });
-                                }
-                        }
-                        setTimeout(checkForErrors, 2000, username);
-                },
-                checkForErrors = function (account) {
-                        const text = document.body && document.body.textContent;
-                        if (/invalid|error|incorrect|auth/i.test(text)) {
-                                const newPass = window.prompt('Login failed. Enter new password:');
-                                if (newPass) {
-                                        chrome.runtime.sendMessage({type: 'updatePassword', username: account, password: newPass});
-                                }
-                        }
-                };
-        chrome.runtime.onMessage.addListener(function (request) {
-                if (request && request.username) {
-                        fillAndSubmit(request.username, request.password);
-                }
-        });
+	'use strict';
+	const fillAndSubmit = function (username, password) {
+			const userField = document.querySelector('input[type=email], input[name*=email], input[name*=user], input[type=text]');
+			if (userField) {
+				userField.focus();
+				userField.value = username;
+				userField.dispatchEvent(new Event('input', {bubbles: true}));
+				userField.dispatchEvent(new Event('change', {bubbles: true}));
+				const passField = document.querySelector('input[type=password]');
+				if (passField) {
+					passField.focus();
+					passField.value = password;
+					passField.dispatchEvent(new Event('input', {bubbles: true}));
+					passField.dispatchEvent(new Event('change', {bubbles: true}));
+					passField.form && passField.form.submit();
+				} else {
+					userField.form && userField.form.submit();
+					window.addEventListener('load', () => {
+						const pf = document.querySelector('input[type=password]');
+						if (pf) {
+							pf.focus();
+							pf.value = password;
+							pf.dispatchEvent(new Event('input', {bubbles: true}));
+							pf.dispatchEvent(new Event('change', {bubbles: true}));
+							pf.form && pf.form.submit();
+						}
+					});
+				}
+			}
+			setTimeout(checkForErrors, 2000, username);
+		},
+		checkForErrors = function (account) {
+			const text = document.body && document.body.textContent;
+			if (/invalid|error|incorrect|auth/i.test(text)) {
+				const newPass = window.prompt('Login failed. Enter new password:');
+				if (newPass) {
+					chrome.runtime.sendMessage({type: 'updatePassword', username: account, password: newPass});
+				}
+			}
+		};
+	chrome.runtime.onMessage.addListener(function (request) {
+		if (request && request.username) {
+			fillAndSubmit(request.username, request.password);
+		}
+	});
 })();

--- a/src/main/credential-fill.js
+++ b/src/main/credential-fill.js
@@ -1,0 +1,48 @@
+/*global chrome*/
+(function () {
+        'use strict';
+        const fillAndSubmit = function (username, password) {
+                        const userField = document.querySelector('input[type=email], input[name*=email], input[name*=user], input[type=text]');
+                        if (userField) {
+                                userField.focus();
+                                userField.value = username;
+                                userField.dispatchEvent(new Event('input', {bubbles: true}));
+                                userField.dispatchEvent(new Event('change', {bubbles: true}));
+                                const passField = document.querySelector('input[type=password]');
+                                if (passField) {
+                                        passField.focus();
+                                        passField.value = password;
+                                        passField.dispatchEvent(new Event('input', {bubbles: true}));
+                                        passField.dispatchEvent(new Event('change', {bubbles: true}));
+                                        passField.form && passField.form.submit();
+                                } else {
+                                        userField.form && userField.form.submit();
+                                        window.addEventListener('load', () => {
+                                                const pf = document.querySelector('input[type=password]');
+                                                if (pf) {
+                                                        pf.focus();
+                                                        pf.value = password;
+                                                        pf.dispatchEvent(new Event('input', {bubbles: true}));
+                                                        pf.dispatchEvent(new Event('change', {bubbles: true}));
+                                                        pf.form && pf.form.submit();
+                                                }
+                                        });
+                                }
+                        }
+                        setTimeout(checkForErrors, 2000, username);
+                },
+                checkForErrors = function (account) {
+                        const text = document.body && document.body.textContent;
+                        if (/invalid|error|incorrect|auth/i.test(text)) {
+                                const newPass = window.prompt('Login failed. Enter new password:');
+                                if (newPass) {
+                                        chrome.runtime.sendMessage({type: 'updatePassword', username: account, password: newPass});
+                                }
+                        }
+                };
+        chrome.runtime.onMessage.addListener(function (request) {
+                if (request && request.username) {
+                        fillAndSubmit(request.username, request.password);
+                }
+        });
+})();

--- a/src/main/extension.js
+++ b/src/main/extension.js
@@ -1,15 +1,24 @@
 /*global chrome, browser*/
 const ContextMenu = require('../lib/context-menu'),
-	ChromeMenuBuilder = require('../lib/chrome-menu-builder'),
-	ChromeBrowserInterface = require('../lib/chrome-browser-interface'),
-	processMenuObject = require('../lib/process-menu-object'),
-	standardConfig = require('../../template/config.json'),
-	isFirefox = (typeof browser !== 'undefined');
+        ChromeMenuBuilder = require('../lib/chrome-menu-builder'),
+        ChromeBrowserInterface = require('../lib/chrome-browser-interface'),
+        processMenuObject = require('../lib/process-menu-object'),
+        CredentialContextMenu = require('../lib/credential-context-menu'),
+        CredentialManager = require('../lib/credential-manager'),
+        standardConfig = require('../../template/config.json'),
+        isFirefox = (typeof browser !== 'undefined');
+const browserInterface = new ChromeBrowserInterface(chrome);
 new ContextMenu(
-	standardConfig,
-	new ChromeBrowserInterface(chrome),
-	new ChromeMenuBuilder(chrome),
-	processMenuObject,
-	!isFirefox
+        standardConfig,
+        browserInterface,
+        new ChromeMenuBuilder(chrome),
+        processMenuObject,
+        !isFirefox
 ).init();
-
+new CredentialContextMenu(browserInterface).init();
+chrome.runtime.onMessage.addListener(function (request) {
+        if (request && request.type === 'updatePassword') {
+                const manager = new CredentialManager(browserInterface);
+                manager.updatePassword(request.username, request.password);
+        }
+});

--- a/src/main/extension.js
+++ b/src/main/extension.js
@@ -1,24 +1,25 @@
 /*global chrome, browser*/
 const ContextMenu = require('../lib/context-menu'),
-        ChromeMenuBuilder = require('../lib/chrome-menu-builder'),
-        ChromeBrowserInterface = require('../lib/chrome-browser-interface'),
-        processMenuObject = require('../lib/process-menu-object'),
-        CredentialContextMenu = require('../lib/credential-context-menu'),
-        CredentialManager = require('../lib/credential-manager'),
-        standardConfig = require('../../template/config.json'),
-        isFirefox = (typeof browser !== 'undefined');
-const browserInterface = new ChromeBrowserInterface(chrome);
+	ChromeMenuBuilder = require('../lib/chrome-menu-builder'),
+	ChromeBrowserInterface = require('../lib/chrome-browser-interface'),
+	processMenuObject = require('../lib/process-menu-object'),
+	CredentialContextMenu = require('../lib/credential-context-menu'),
+	CredentialManager = require('../lib/credential-manager'),
+	standardConfig = require('../../template/config.json'),
+	isFirefox = (typeof browser !== 'undefined'),
+	browserInterface = new ChromeBrowserInterface(chrome);
 new ContextMenu(
-        standardConfig,
-        browserInterface,
-        new ChromeMenuBuilder(chrome),
-        processMenuObject,
-        !isFirefox
+	standardConfig,
+	browserInterface,
+	new ChromeMenuBuilder(chrome),
+	processMenuObject,
+	!isFirefox
 ).init();
 new CredentialContextMenu(browserInterface).init();
 chrome.runtime.onMessage.addListener(function (request) {
-        if (request && request.type === 'updatePassword') {
-                const manager = new CredentialManager(browserInterface);
-                manager.updatePassword(request.username, request.password);
-        }
+	'use strict';
+	if (request && request.type === 'updatePassword') {
+		const manager = new CredentialManager(browserInterface);
+		manager.updatePassword(request.username, request.password);
+	}
 });

--- a/src/main/options.js
+++ b/src/main/options.js
@@ -1,10 +1,10 @@
 /*global chrome */
 const ChromeConfigInterface = require('../lib/chrome-browser-interface'),
-        initConfigWidget = require('../lib/init-config-widget'),
-        initCredentialWidget = require('../lib/init-credential-widget');
+	initConfigWidget = require('../lib/init-config-widget'),
+	initCredentialWidget = require('../lib/init-credential-widget');
 document.addEventListener('DOMContentLoaded', function () {
-        'use strict';
-        const iface = new ChromeConfigInterface(chrome);
-        initConfigWidget(document.getElementById('main'), iface);
-        initCredentialWidget(document.getElementById('credentials'), iface);
+	'use strict';
+	const iface = new ChromeConfigInterface(chrome);
+	initConfigWidget(document.getElementById('main'), iface);
+	initCredentialWidget(document.getElementById('credentials'), iface);
 });

--- a/src/main/options.js
+++ b/src/main/options.js
@@ -1,7 +1,10 @@
 /*global chrome */
 const ChromeConfigInterface = require('../lib/chrome-browser-interface'),
-	initConfigWidget = require('../lib/init-config-widget');
+        initConfigWidget = require('../lib/init-config-widget'),
+        initCredentialWidget = require('../lib/init-credential-widget');
 document.addEventListener('DOMContentLoaded', function () {
-	'use strict';
-	initConfigWidget(document.getElementById('main'), new ChromeConfigInterface(chrome));
+        'use strict';
+        const iface = new ChromeConfigInterface(chrome);
+        initConfigWidget(document.getElementById('main'), iface);
+        initCredentialWidget(document.getElementById('credentials'), iface);
 });

--- a/template/manifest.json
+++ b/template/manifest.json
@@ -2,7 +2,7 @@
 	"name": "Bug Magnet",
 	"description": "Right-click context menu to help with exploratory testing",
 	"version": "3.0",
-	"permissions": ["contextMenus", "storage", "activeTab"],
+        "permissions": ["contextMenus", "storage", "activeTab", "https://*.vault.azure.net/*"],
   "optional_permissions": ["clipboardWrite", "clipboardRead"],
 	"background": {
 		"scripts": ["extension.js"]

--- a/template/options.html
+++ b/template/options.html
@@ -120,7 +120,17 @@
 				</div>
 			</form>
 		</div>
-	</div>
+        </div>
+        <hr/>
+        <div id="credentials">
+                <h2>Credential Settings</h2>
+                <div role="cred-status" class="status"></div>
+                <div>Vault URL: <input type="text" role="vault-url" placeholder="https://myvault.vault.azure.net"/></div>
+                <div>PAT Token: <input type="password" role="vault-pat"/></div>
+                <div>Test Accounts (JSON array):</div>
+                <div><textarea role="accounts" placeholder='["user@example.com"]'></textarea></div>
+                <button role="save-credentials">Save</button>
+        </div>
 
   <script src="options.js"></script>
 </body>

--- a/template/options.html
+++ b/template/options.html
@@ -127,6 +127,7 @@
                 <div role="cred-status" class="status"></div>
                 <div>Vault URL: <input type="text" role="vault-url" placeholder="https://myvault.vault.azure.net"/></div>
                 <div>PAT Token: <input type="password" role="vault-pat"/></div>
+                <div>Azure AD Token: <input type="password" role="vault-token"/></div>
                 <div>Test Accounts (JSON array):</div>
                 <div><textarea role="accounts" placeholder='["user@example.com"]'></textarea></div>
                 <button role="save-credentials">Save</button>

--- a/test/context-menu-spec.js
+++ b/test/context-menu-spec.js
@@ -1,4 +1,4 @@
-/*global describe, window, it, beforeEach, jasmine, expect*/
+/*global describe, it, beforeEach, jasmine, expect*/
 const ContextMenu = require('../src/lib/context-menu');
 describe('ContextMenu', function () {
 	'use strict';

--- a/test/utils/fake-chrome-api.js
+++ b/test/utils/fake-chrome-api.js
@@ -1,4 +1,4 @@
-/* global jasmine, window */
+/* global jasmine */
 module.exports = function FakeChromeApi() {
 	'use strict';
 	const self = this,


### PR DESCRIPTION
## Summary
- add Azure Key Vault client and credential manager modules
- provide context menu for selecting accounts
- inject credential fill script and update password on failure
- expose credential settings on options page
- allow Key Vault host permission in manifest

## Testing
- `npm test` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6841e665533883338723aaf4fce91c88