### PR TITLE
Migrate extension to Manifest V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ To build the extension files run:
 npm run pack-extension
 ```
 
-This creates a `pack` directory containing the packaged extension. In Chrome open `chrome://extensions`, enable *Developer mode* and choose **Load unpacked** pointing to this directory.
+This creates a `pack` directory containing the packaged extension, including the manifest and static assets. In Chrome open `chrome://extensions`, enable *Developer mode* and choose **Load unpacked** pointing to this directory.
+
+The extension now uses Manifest V3 with a background service worker. Older Chromium builds may not support this format.
 
 On Windows you can package the extension and produce a zip archive by running:
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test-chrome": "testem -l Chrome",
     "sourcemap": "sourcemap-lookup",
     "prepack-extension": "rm -rf pack && cp -R template pack",
-    "pack-extension": "webpack --config webpack.config.js"
+    "pack-extension": "npm run prepack-extension && webpack --config webpack.config.js"
   },
   "devDependencies": {
     "eslint": "^4.11.0",

--- a/src/lib/chrome-browser-interface.js
+++ b/src/lib/chrome-browser-interface.js
@@ -2,7 +2,18 @@ module.exports = function ChromeBrowserInterface(chrome) {
 	'use strict';
 	const self = this;
 	self.saveOptions = function (options) {
-		chrome.storage.sync.set(options);
+	        return new Promise((resolve, reject) => {
+	                chrome.storage.sync.get(null, existing => {
+	                        const merged = Object.assign({}, existing, options);
+	                        chrome.storage.sync.set(merged, () => {
+	                                if (chrome.runtime.lastError) {
+	                                        reject(chrome.runtime.lastError);
+	                                } else {
+	                                        resolve();
+	                                }
+	                        });
+	                });
+	        });
 	};
 	self.getOptionsAsync = function () {
 		return new Promise((resolve) => {

--- a/src/lib/init-config-widget.js
+++ b/src/lib/init-config-widget.js
@@ -18,12 +18,12 @@ module.exports = function initConfigWidget(domElement, browserInterface) {
 			link.textContent = url.replace(/.*\//g, '');
 			parent.appendChild(link);
 		},
-		saveOptions = function () {
-			browserInterface.saveOptions({
-				additionalMenus: additionalMenus,
-				skipStandard: skipStandard
-			});
-		},
+	        saveOptions = function () {
+	                return browserInterface.saveOptions({
+	                        additionalMenus: additionalMenus,
+	                        skipStandard: skipStandard
+	                }).catch(showErrorMsg);
+	        },
 		rebuildMenu = function () {
 			list.innerHTML = '';
 			if (additionalMenus && additionalMenus.length) {

--- a/src/lib/init-credential-widget.js
+++ b/src/lib/init-credential-widget.js
@@ -13,17 +13,23 @@ module.exports = function initCredentialWidget(domElement, browserInterface) {
 				accountsField.value = Array.isArray(opts.accounts) ? JSON.stringify(opts.accounts, null, 2) : '[]';
 			});
 		},
-		save = function () {
-			try {
-				const acc = accountsField.value ? JSON.parse(accountsField.value) : [];
-				browserInterface.saveOptions({ vaultUrl: vaultField.value, vaultPat: patField.value, vaultToken: tokenField.value, accounts: acc });
-				status.textContent = 'Saved';
-				setTimeout(() => status.textContent = '', 1000);
-			} catch (e) {
-				console.error(e);
-				status.textContent = 'Invalid accounts JSON';
-			}
-		};
+	        save = function () {
+	                try {
+	                        const acc = accountsField.value ? JSON.parse(accountsField.value) : [];
+	                        browserInterface.saveOptions({ vaultUrl: vaultField.value, vaultPat: patField.value, vaultToken: tokenField.value, accounts: acc })
+	                                .then(() => {
+	                                        status.textContent = 'Saved';
+	                                        setTimeout(() => status.textContent = '', 1000);
+	                                })
+	                                .catch(err => {
+	                                        console.error(err);
+	                                        status.textContent = err.message || 'Error saving';
+	                                });
+	                } catch (e) {
+	                        console.error(e);
+	                        status.textContent = 'Invalid accounts JSON';
+	                }
+	        };
 	domElement.querySelector('[role=save-credentials]').addEventListener('click', save);
 	restore();
 };

--- a/template/manifest.json
+++ b/template/manifest.json
@@ -2,20 +2,22 @@
 	"name": "Bug Magnet",
 	"description": "Right-click context menu to help with exploratory testing",
 	"version": "3.0",
-        "permissions": ["contextMenus", "storage", "activeTab", "https://*.vault.azure.net/*"],
-  "optional_permissions": ["clipboardWrite", "clipboardRead"],
-	"background": {
-		"scripts": ["extension.js"]
-	},
-	"manifest_version": 2,
+        "manifest_version": 3,
+        "permissions": ["contextMenus", "storage", "activeTab"],
+        "host_permissions": ["https://*.vault.azure.net/*"],
+        "optional_permissions": ["clipboardWrite", "clipboardRead"],
+        "background": {
+                "service_worker": "extension.js"
+        },
 	"icons": {
 		"128": "magnet.png",
 		"16": "magnet-16.png"
 	},
   "homepage_url": "https://bugmagnet.org",
   "author": "Gojko Adzic https://gojko.net",
-	"options_ui": {
-		"page": "options.html",
-		"chrome_style": true
-	}
+  "action": {},
+        "options_ui": {
+                "page": "options.html",
+                "chrome_style": true
+        }
 }

--- a/test/init-credential-widget-spec.js
+++ b/test/init-credential-widget-spec.js
@@ -1,0 +1,70 @@
+/*global describe, it, expect, beforeEach, afterEach, jasmine */
+const initCredentialWidget = require('../src/lib/init-credential-widget');
+
+describe('initCredentialWidget', function () {
+	'use strict';
+	let container, browserInterface, status, saveBtn, vaultUrl, pat, token, accounts;
+	const template = `
+		<input role="vault-url" id="vaultUrl"/>
+		<input role="vault-pat" id="pat"/>
+		<input role="vault-token" id="token"/>
+		<textarea role="accounts" id="accounts"></textarea>
+		<span role="cred-status" id="status"></span>
+		<button role="save-credentials" id="save">Save</button>`;
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		container.innerHTML = template;
+		document.body.appendChild(container);
+		browserInterface = jasmine.createSpyObj('browserInterface', ['saveOptions', 'getOptionsAsync']);
+		browserInterface.getOptionsAsync.and.returnValue(Promise.resolve({
+			vaultUrl: 'a',
+			vaultPat: 'b',
+			vaultToken: 'c',
+			accounts: [{n:1}]
+		}));
+		browserInterface.saveOptions.and.returnValue(Promise.resolve());
+		initCredentialWidget(container, browserInterface);
+		status = document.getElementById('status');
+		saveBtn = document.getElementById('save');
+		vaultUrl = document.getElementById('vaultUrl');
+		pat = document.getElementById('pat');
+		token = document.getElementById('token');
+		accounts = document.getElementById('accounts');
+	});
+
+	afterEach(() => {
+		container.remove();
+	});
+
+	it('restores saved values on load', () => {
+		expect(vaultUrl.value).toEqual('a');
+		expect(pat.value).toEqual('b');
+		expect(token.value).toEqual('c');
+		expect(accounts.value).toMatch(/\[/);
+	});
+
+	it('saves values when clicking save', done => {
+		vaultUrl.value = 'x';
+		pat.value = 'y';
+		token.value = 'z';
+		accounts.value = '[{"u":1}]';
+		saveBtn.click();
+		setTimeout(() => {
+			expect(browserInterface.saveOptions).toHaveBeenCalledWith({
+				vaultUrl: 'x',
+				vaultPat: 'y',
+				vaultToken: 'z',
+				accounts: [{u: 1}]
+			});
+			done();
+		}, 0);
+	});
+
+	it('shows error for invalid JSON', () => {
+		accounts.value = '[';
+		saveBtn.click();
+		expect(status.textContent).toMatch(/Invalid/);
+		expect(browserInterface.saveOptions).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- switch manifest to version 3 and use a service worker
- run `prepack-extension` before webpack when packaging
- merge options when saving and surface save errors
- update options and credential widgets for async save
- add a basic credential widget test
- document new build instructions

## Testing
- `npm test` *(fails: `testem` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fdffae2083338e13c7a328e610fd