### PR TITLE
Fix eslint issues

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,27 +1,27 @@
 module.exports = [
-  {
-    files: ['**/*.js'],
-    languageOptions: {
-      ecmaVersion: 6,
-      sourceType: 'script',
-      globals: {
-        chrome: 'readonly',
-        browser: 'readonly',
-        module: 'writable',
-        require: 'readonly'
-      }
-    },
-    rules: {
-      semi: ['error', 'always'],
-      strict: ['error', 'function'],
-      'no-unused-vars': 'error',
-      indent: ['error', 'tab'],
-      'no-const-assign': 'error',
-      'one-var': 'error',
-      'prefer-const': 'error',
-      'no-var': 'error',
-      'no-plusplus': 'off',
-      quotes: ['error', 'single', { avoidEscape: true, allowTemplateLiterals: true }]
-    }
-  }
+	{
+	  files: ['**/*.js'],
+	  languageOptions: {
+	    ecmaVersion: 6,
+	    sourceType: 'script',
+	    globals: {
+	      chrome: 'readonly',
+	      browser: 'readonly',
+	      module: 'writable',
+	      require: 'readonly'
+	    }
+	  },
+	  rules: {
+	    semi: ['error', 'always'],
+	    strict: ['error', 'function'],
+	    'no-unused-vars': 'error',
+	    indent: ['error', 'tab'],
+	    'no-const-assign': 'error',
+	    'one-var': 'error',
+	    'prefer-const': 'error',
+	    'no-var': 'error',
+	    'no-plusplus': 'off',
+	    quotes: ['error', 'single', { avoidEscape: true, allowTemplateLiterals: true }]
+	  }
+	}
 ];

--- a/scripts/installDependencies.js
+++ b/scripts/installDependencies.js
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
-'use strict';
-const { execSync } = require('child_process');
-
-try {
-  execSync('npm install', { stdio: 'inherit' });
-} catch (err) {
-  console.error('Failed to install dependencies:', err.message);
-  process.exit(1);
-}
+(function () {
+	'use strict';
+	const { execSync } = require('child_process');
+	
+	try {
+		execSync('npm install', { stdio: 'inherit' });
+	} catch (err) {
+		console.error('Failed to install dependencies:', err.message);
+		process.exit(1);
+	}
+})();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-/*global require, module, __dirname, process, console */
+/*global require, module, __dirname */
 const path = require('path'),
 	recursiveLs = require('fs-readdir-recursive'),
 	entries = {},


### PR DESCRIPTION
## Summary
- adjust indentation style in `eslint.config.js`
- wrap dependency installation script in an IIFE and fix indentation
- remove unused globals from `webpack.config.js`

## Testing
- `npx eslint .`
- `npm test` *(fails: `rimraf: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848f46831688333a9d69e0deba78103