### PR TITLE
Fix handler name and context menu creation

### DIFF
--- a/src/lib/copy-request-handler.js
+++ b/src/lib/copy-request-handler.js
@@ -1,5 +1,5 @@
 const getRequestValue = require('./get-request-value');
-module.exports = function pasteRequestHandler(browserInterface, tabId, request) {
+module.exports = function copyRequestHandler(browserInterface, tabId, request) {
 	'use strict';
 	browserInterface.copyToClipboard(getRequestValue(request));
 };

--- a/src/main/extension.js
+++ b/src/main/extension.js
@@ -11,14 +11,16 @@ const ContextMenu = require('../lib/context-menu'),
 
 function initMenus() {
 	'use strict';
-	new ContextMenu(
-		standardConfig,
-		browserInterface,
-		new ChromeMenuBuilder(chrome),
-		processMenuObject,
-		!isFirefox
-	).init();
-	new CredentialContextMenu(browserInterface).init();
+	chrome.contextMenus.removeAll(() => {
+		new ContextMenu(
+			standardConfig,
+			browserInterface,
+			new ChromeMenuBuilder(chrome),
+			processMenuObject,
+			!isFirefox
+		).init();
+		new CredentialContextMenu(browserInterface).init();
+	});
 }
 
 chrome.runtime.onInstalled.addListener(initMenus);


### PR DESCRIPTION
## Summary
- fix copy request handler name
- avoid duplicate context menus by clearing previous entries

## Testing
- `npm test` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875cfc91a80833398d617960d5e1cf7